### PR TITLE
Added init function in main.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+CXX          := g++
+CXX_FLAGS := -std=c++17 -ggdb -L/usr/local/opt/openssl/lib -I /usr/local/opt/openssl/include
+BIN        := bin
+SRC        := src
+INCLUDE    := 
+LIB        := lib
+LIBRARIES    := 
+EXECUTABLE    := main
+
+
+
+all: $(BIN)/$(EXECUTABLE)
+
+run: clean all
+	@echo "run called"
+	./$(BIN)/$(EXECUTABLE)
+
+$(BIN)/$(EXECUTABLE): $(SRC)/*.cpp
+	$(CXX) $(CXX_FLAGS) -I$(INCLUDE) -L$(LIB) $^ -o $ ~/imperium/$(BIN)/$(EXECUTABLE) $(LIBRARIES) -lssl -lcrypto
+
+clean:
+	@echo "clean called"
+	@rm -rf -d ~/imperium/$(BIN)/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,16 @@
+ #!/bin/bash
+#  brew update
+#  brew install openssl
+#  brew install libssl-dev
+ mkdir -p ~/imperium/bin
+ cp imperium.sh ~/imperium
+cd .. 
+make
+cd ~/imperium/bin || echo "error"
+chmod +x main
+cd ..
+if grep -q "source $PWD/imperium.sh" "$PWD/../.bash_profile" ; then
+    echo 'already installed bash source';
+else
+    echo "source $PWD/imperium.sh" >> ~/.bash_profile;
+fi

--- a/scripts/imperium.sh
+++ b/scripts/imperium.sh
@@ -1,0 +1,7 @@
+ function imperium(){
+ DIR=$PWD
+ export dir=$DIR
+ cd ~/imperium/bin || echo "Error"
+ ./main "$@"
+ cd "$DIR" || echo "Error"
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <utility>
+#include <fstream>
+#include <string>
+#include <string.h>
+#include <sys/stat.h>
+#include <experimental/filesystem>
+
+namespace fs = std::filesystem;
+
+std::string root = "";
+
+void init(std::string path)
+{
+
+    struct stat buffer;
+
+    if (stat((path + "/.imperium").c_str(), &buffer) == 0)
+    {
+        std::cout << "Repository has already been initialized!\n";
+    }
+    else
+    {
+
+        std::string ignorepath = path + "/.imperiumignore";
+        std::ofstream ignore(ignorepath.c_str());
+
+        ignore << ".gitignore\n.git\n.imperiumignore\n.imperium\n.node_modules\n";
+
+        ignore.close();
+
+        path += "/.imperium";
+        int created = mkdir(path.c_str(), 0777);
+
+        if (created == 0)
+        {
+
+            std::string commitlog = path + "/commitlog";
+            std::ofstream commit(commitlog.c_str());
+            commit.close();
+
+            std::string addlog = path + "/addlog";
+            std::ofstream add(addlog.c_str());
+            add.close();
+
+            std::string conflictlog = path + "/conflictlog";
+            std::ofstream conflict(conflictlog.c_str());
+            conflict.close();
+
+            std::cout << " Initialized an empty repository!!\n";
+        }
+        else
+        {
+            std::cout << "ERROR\n";
+        }
+    }
+}
+
+int main(int argc, char *argv[])
+{
+
+    const std::string dir = getenv("dir");
+    root = dir;
+
+    if (strcmp(argv[1], "init") == 0)
+    {
+        init(root);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Added the init() function in main.cpp . I have used .bash_profile instead of .bashrc in the shell scripts. Also std::filesystem has been used instead of std::experimental::filesystem as std::experimental::filesystem was giving a warning saying:
 
**'filesystem' is deprecated: std::experimental::filesystem has now been deprecated in
      favor of C++17's std::filesystem. Please stop using it and start using std::filesystem.**